### PR TITLE
Allow user_medias to be optional. (#264)

### DIFF
--- a/changelogs/fragments/264-allow-user_medias-to-be-optional.yaml
+++ b/changelogs/fragments/264-allow-user_medias-to-be-optional.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_user - user_medias now defaults to None and is optional (https://github.com/ansible-collections/community.zabbix/pull/264).

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -119,7 +119,7 @@ options:
     user_medias:
         description:
             - Set the user's media.
-        default: []
+            - If not set, makes no changes to media.
         suboptions:
             mediatype:
                 description:
@@ -365,7 +365,8 @@ class User(ZabbixBase):
                                         autologin, autologout, refresh, rows_per_page, url, user_medias, user_type,
                                         timezone, role_name, override_passwd):
 
-        user_medias = self.convert_user_medias_parameter_types(user_medias)
+        if user_medias:
+            user_medias = self.convert_user_medias_parameter_types(user_medias)
 
         # existing data
         existing_data = copy.deepcopy(zbx_user[0])
@@ -407,8 +408,12 @@ class User(ZabbixBase):
             'refresh': refresh,
             'rows_per_page': rows_per_page,
             'url': url,
-            'user_medias': sorted(user_medias, key=lambda x: x['sendto']),
         }
+
+        if user_medias:
+            request_data['user_medias'] = sorted(user_medias, key=lambda x: x['sendto'])
+        else:
+            del existing_data['user_medias']
 
         if override_passwd:
             request_data['passwd'] = passwd
@@ -434,7 +439,8 @@ class User(ZabbixBase):
     def add_user(self, alias, name, surname, user_group_ids, passwd, lang, theme, autologin, autologout, refresh,
                  rows_per_page, url, user_medias, user_type, not_ldap, timezone, role_name):
 
-        user_medias = self.convert_user_medias_parameter_types(user_medias)
+        if user_medias:
+            user_medias = self.convert_user_medias_parameter_types(user_medias)
 
         user_ids = {}
 
@@ -450,8 +456,9 @@ class User(ZabbixBase):
             'refresh': refresh,
             'rows_per_page': rows_per_page,
             'url': url,
-            'user_medias': user_medias,
         }
+        if user_medias:
+            request_data['user_medias'] = user_medias
 
         if LooseVersion(self._zbx_api_version) < LooseVersion('4.0') or not_ldap:
             request_data['passwd'] = passwd
@@ -480,7 +487,8 @@ class User(ZabbixBase):
     def update_user(self, zbx_user, alias, name, surname, user_group_ids, passwd, lang, theme, autologin, autologout,
                     refresh, rows_per_page, url, user_medias, user_type, timezone, role_name, override_passwd):
 
-        user_medias = self.convert_user_medias_parameter_types(user_medias)
+        if user_medias:
+            user_medias = self.convert_user_medias_parameter_types(user_medias)
 
         user_ids = {}
 
@@ -517,16 +525,18 @@ class User(ZabbixBase):
                 self._module.fail_json(msg="Failed to update user %s: %s" % (alias, e))
 
             try:
-                user_ids = self._zapi.user.updatemedia({
-                    'users': [{'userid': zbx_user[0]['userid']}],
-                    'medias': user_medias
-                })
+                if user_medias:
+                    user_ids = self._zapi.user.updatemedia({
+                        'users': [{'userid': zbx_user[0]['userid']}],
+                        'medias': user_medias
+                    })
             except Exception as e:
                 self._module.fail_json(msg="Failed to update user medias %s: %s" % (alias, e))
 
         if LooseVersion(self._zbx_api_version) >= LooseVersion('3.4'):
             try:
-                request_data['user_medias'] = user_medias
+                if user_medias:
+                    request_data['user_medias'] = user_medias
                 user_ids = self._zapi.user.update(request_data)
             except Exception as e:
                 self._module.fail_json(msg="Failed to update user %s: %s" % (alias, e))
@@ -570,7 +580,7 @@ def main():
         refresh=dict(type='str', default='30'),
         rows_per_page=dict(type='str', default='50'),
         after_login_url=dict(type='str', default=''),
-        user_medias=dict(type='list', default=[], elements='dict',
+        user_medias=dict(type='list', default=None, elements='dict',
                          options=dict(mediatype=dict(type='str', default='Email'),
                                       sendto=dict(type='str', required=True),
                                       period=dict(type='str', default='1-7,00:00-24:00'),

--- a/tests/integration/targets/test_zabbix_user/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user/tasks/main.yml
@@ -858,6 +858,30 @@
     that:
     - delete_user_group_existing_user_result.changed is sameas true
 
+- name: test - optional user_medias
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example1
+    name: example2
+    surname: test2
+    usrgrps:
+      - Zabbix administrators
+    passwd: update_password
+    autologout: 500
+    refresh: 60
+    rows_per_page: 300
+    after_login_url: http://example.com
+    theme: dark-theme
+    type: Zabbix super admin
+    lang: en_GB
+  register: update_user_optional_user_medias_existing_user_result
+
+- assert:
+    that:
+    - update_user_optional_user_medias_existing_user_result.changed is sameas False
+
 - name: test - Delete existing user with check_mode and diff
   zabbix_user:
     server_url: "{{ zabbix_server_url }}"


### PR DESCRIPTION
* Allow user_medias to be optional.

* syntax fixes

* additional syntax fix

* adjusted default documentation for none

* modification to support zabbix 3.0

* Changelog updated, test created

* fix typo

* Update changelogs/fragments/264-allow-user_medias-to-be-optional.yaml

Co-authored-by: sky-joker <megane@kurobuti.com>

Co-authored-by: Brandon Earl Booker <bbooker@vt.edu>
Co-authored-by: Elrondvega <elrondvega@vt.edu>
Co-authored-by: sky-joker <sky.jokerxx@gmail.com>